### PR TITLE
fix: check md5 without == at the end

### DIFF
--- a/lib/active_storage/service/ftp_service.rb
+++ b/lib/active_storage/service/ftp_service.rb
@@ -134,7 +134,7 @@ module ActiveStorage
 
     def ensure_integrity_of(key, checksum)
       response = request_head(key)
-      unless "#{response['Content-MD5']}==" == checksum
+      unless "#{response['Content-MD5']}==" == checksum || reponse["Content-MD5"] == checksum
         delete key
         raise ActiveStorage::IntegrityError
       end

--- a/lib/active_storage/service/ftp_service.rb
+++ b/lib/active_storage/service/ftp_service.rb
@@ -134,7 +134,7 @@ module ActiveStorage
 
     def ensure_integrity_of(key, checksum)
       response = request_head(key)
-      unless "#{response['Content-MD5']}==" == checksum || reponse["Content-MD5"] == checksum
+      unless "#{response['Content-MD5']}==" == checksum || response["Content-MD5"] == checksum
         delete key
         raise ActiveStorage::IntegrityError
       end


### PR DESCRIPTION
The MD5 (or whatever algorithm) is supposed to always generate the [same output](https://stackoverflow.com/questions/4354377/does-the-md5-algorithm-always-generate-the-same-output-for-the-same-string).
I do not understand what use case requires appending the double equal (`==`) the end of the `Content-MD5` header.
Anyway, I think this fix helps to support both cases in which double equal is present or not at the end.